### PR TITLE
splitting rbac file correctly

### DIFF
--- a/01_pacman-rbac.yaml
+++ b/01_pacman-rbac.yaml
@@ -18,6 +18,7 @@ roleRef:
   kind: ClusterRole
   name: pacman 
   apiGroup: rbac.authorization.k8s.io
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:


### PR DESCRIPTION
missing break between definitions